### PR TITLE
Fix RealmEye image downloader to handle rotating asset URLs

### DIFF
--- a/image_downloader.py
+++ b/image_downloader.py
@@ -1,18 +1,46 @@
 import os
+import re
+
 import requests
+
+
+BASE_REALMEYE_URL = "https://www.realmeye.com"
+ASSET_TOKEN_FALLBACK = "gu"
+
+
+def _get_asset_token() -> str:
+    response = requests.get(BASE_REALMEYE_URL, timeout=10)
+    response.raise_for_status()
+
+    token_match = re.search(r'"/s/([^/]+)/css/[^"]+\.css"', response.text)
+    if token_match:
+        return token_match.group(1)
+
+    return ASSET_TOKEN_FALLBACK
+
+
+def _download_image(image_name: str, asset_path: str) -> None:
+    response = requests.get(asset_path, stream=True, timeout=10)
+    response.raise_for_status()
+
+    os.makedirs("./images", exist_ok=True)
+
+    with open(os.path.join("./images", image_name), 'wb') as file:
+        for chunk in response.iter_content(1024):
+            file.write(chunk)
+
+    print(f"Image saved as {image_name}")
+
 
 def Download_Images() -> None:
     try:
-        response = requests.get("https://www.realmeye.com/s/gu/img/sheets.png", stream=True)
-        response.raise_for_status()
+        asset_token = _get_asset_token()
+    except requests.exceptions.RequestException as e:
+        print(f"Error getting latest RealmEye asset token: {e}. Falling back to '{ASSET_TOKEN_FALLBACK}'.")
+        asset_token = ASSET_TOKEN_FALLBACK
 
-        file_name = os.path.basename("sheets.png")
-        os.makedirs("./images", exist_ok=True)
-
-        with open(os.path.join("./images", file_name), 'wb') as file:
-            for chunk in response.iter_content(1024):
-                file.write(chunk)
-        print(f"Image saved as {file_name}")
+    try:
+        _download_image("sheets.png", f"{BASE_REALMEYE_URL}/s/{asset_token}/img/sheets.png")
 
     except requests.exceptions.RequestException as e:
         print(f"Error downloading image: {e}, sheets.png")
@@ -20,15 +48,7 @@ def Download_Images() -> None:
             print(f"An error occurred: {e}, sheets.png")
 
     try:
-        response = requests.get("https://www.realmeye.com/s/gu/css/renders.png", stream=True)
-        response.raise_for_status()
-
-        file_name = os.path.basename("renders.png")
-
-        with open(os.path.join("./images", file_name), 'wb') as file:
-            for chunk in response.iter_content(1024):
-                file.write(chunk)
-        print(f"Image saved as {file_name}")
+        _download_image("renders.png", f"{BASE_REALMEYE_URL}/s/{asset_token}/css/renders.png")
 
     except requests.exceptions.RequestException as e:
         print(f"Error downloading image: {e}, renders.png")


### PR DESCRIPTION
### Motivation
- RealmEye serves static image assets under a rotating `/s/<token>/...` prefix, and hardcoded `/s/gu/...` links break when the token changes causing missing sprites.

### Description
- Add `BASE_REALMEYE_URL` and `ASSET_TOKEN_FALLBACK` constants and a `_get_asset_token()` function that discovers the current `/s/<token>/...` token from the RealmEye homepage.
- Add a reusable `_download_image()` helper to centralize request and file-write logic and reduce duplication.
- Update `Download_Images()` to fetch the token, fall back to `ASSET_TOKEN_FALLBACK` if discovery fails, and construct dynamic URLs for `sheets.png` and `renders.png` with error handling.

### Testing
- Ran `python -m py_compile image_downloader.py` which succeeded.
- Executed `python - <<'PY'\nfrom image_downloader import Download_Images\nDownload_Images()\nPY` which exercised token discovery, fallback, and download error paths; the environment blocked outbound access to RealmEye (proxy), so the code fell back to the `gu` token and printed download errors as expected, validating the fallback and error handling logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994ed6330fc832db02a63b8b8a40dd0)