### PR TITLE
Fix guild death notification crash and channel lookup

### DIFF
--- a/snitch_bot.py
+++ b/snitch_bot.py
@@ -4,6 +4,7 @@ import image_downloader as imd
 import guild_graveyard as gg
 import json
 import os
+from datetime import datetime
 from dotenv import load_dotenv
 from pathlib import Path
 import Realm_image_parser as RIP
@@ -42,8 +43,21 @@ async def run_guild_graveyard():
             f.close()
             RIP.death_image_combiner(latest_death)
             death_image = discord.File("./images/output.png")
-            channel = client.get_channel(int(channel_id))
-            await channel.send(f"**{latest_death['player-name']}** died on **{latest_death['time'].split('T')[0]} at {latest_death['time'].split('T')[1].split('Z')[0]}**\n"
+            channel = bot.get_channel(int(channel_id))
+            death_time = latest_death.get('time', '')
+            if 'T' in death_time:
+                death_date, death_clock = death_time.split('T', 1)
+                death_clock = death_clock.split('Z')[0]
+            else:
+                try:
+                    parsed_time = datetime.fromisoformat(death_time.replace('Z', '+00:00'))
+                    death_date = parsed_time.strftime('%Y-%m-%d')
+                    death_clock = parsed_time.strftime('%H:%M:%S')
+                except ValueError:
+                    death_date = death_time
+                    death_clock = "unknown time"
+
+            await channel.send(f"**{latest_death['player-name']}** died on **{death_date} at {death_clock}**\n"
                                f"**Killed by:** {latest_death['killed_by']}\n**Base Fame:** {latest_death['base_fame']} **Total Fame:** {latest_death['total_fame']}\n"
                                f"**Stats:** {latest_death['stats']}", file=death_image)
             RIP.delete_all_files_in_folder("./itempics")


### PR DESCRIPTION
### Motivation
- Prevent a runtime `IndexError` in the guild graveyard notification caused by assuming the death `time` string always contains a `T` delimiter. 
- Ensure the code references the actual bot instance for channel lookup instead of an undefined `client` reference.

### Description
- Replaced `client.get_channel(...)` with `bot.get_channel(...)` to use the correct `Bot` instance. 
- Added `from datetime import datetime` and defensive parsing of `latest_death.get('time', '')` that handles ISO-like `T` timestamps, falls back to `datetime.fromisoformat` for `Z`-terminated strings, and uses a safe fallback if parsing fails. 
- Constructed `death_date` and `death_clock` variables and used them in the outgoing message to avoid splitting errors when the API returns unexpected time formats.

### Testing
- Ran `python -m py_compile snitch_bot.py` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995392511bc832d905062d15c545058)